### PR TITLE
Allow defining ES conf params via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Description
 
 This is the official Elasticsearch image created by Elastic Inc.
-Elasticsearch is built with [x-pack](https://www.elastic.co/guide/en/x-pack/current/index.html)
+Elasticsearch is built with [x-pack](https://www.elastic.co/guide/en/x-pack/current/index.html).
 
 ## Image tags and hosting
 
@@ -64,11 +64,11 @@ This example uses a [Docker named volume](https://docs.docker.com/engine/tutoria
 
 
 ``` shell
-docker run -d -p 9200:9200 -v esdatavolume1:/usr/share/elasticsearch/data --name elasticsearch1 $ELASTIC_REG/elasticsearch bin/elasticsearch -E discovery.zen.minimum_master_nodes=2
+docker run -d -p 9200:9200 -e "discovery.zen.minimum_master_nodes=2" -v esdatavolume1:/usr/share/elasticsearch/data --name elasticsearch1 $ELASTIC_REG/elasticsearch
 ```
 
 ``` shell
-docker run -d -P -v esdatavolume2:/usr/share/elasticsearch/data --name elasticsearch2 --link elasticsearch1 $ELASTIC_REG/elasticsearch bin/elasticsearch -E discovery.zen.minimum_master_nodes=2 -E discovery.zen.ping.unicast.hosts=elasticsearch1
+docker run -d -P -e "discovery.zen.minimum_master_nodes=2" -e "discovery.zen.ping.unicast.hosts=elasticsearch1" -v esdatavolume2:/usr/share/elasticsearch/data --name elasticsearch2 --link elasticsearch1 $ELASTIC_REG/elasticsearch
 ```
 
 ### Security note
@@ -91,41 +91,41 @@ Elasticsearch logs go to the console.
 
 ### Notes for production use and defaults
 
-1. It is important to correctly set capabilities and ulimits via Docker cli. The following are required, also see [docker-compose.yml](https://github.com/elastic/elasticsearch-docker/blob/master/docker-compose.yml):
+1. Defining [elasticsearch parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html#settings) can be done with one of the following methods:
+
+  - Create your own `custom_elasticsearch.yml` and override the default shipped with the image using `-v custom_elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml`
+  - Present the parameters via docker environment variables.
+    For example to define the cluster name with docker run you'd need to pass `-e "cluster.name=mynewclustername"`. Double quotes are required.
+
+    Note that there is a difference in defining [default settings](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/settings.html#_setting_default_settings) and normal settings. The former are prefixed with `default.` and can not override normal settings, if defined.
+  - Override the default [CMD](https://docs.docker.com/engine/reference/run/#cmd-default-command-or-options).
+    For example to define the cluster name you'd type: `docker run <various parameters> bin/elasticsearch -Ecluster.name=mynewclustername`
+
+2. It is important to correctly set capabilities and ulimits via Docker cli. The following are required, also see [docker-compose.yml](https://github.com/elastic/elasticsearch-docker/blob/master/docker-compose.yml):
    `--cap-add=IPC_LOCK --ulimit memlock=-1:-1 --ulimit nofile=65536:65536`.
 
-   Also ensure `bootstrap.memory_lock` is set to `true` as explained in the [Elasticsearch Docs](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/setup-configuration-memory.html#mlockall). This can be achieved either by defining the parameter in a custom `elasticsearch.yml` or override the [CMD](https://docs.docker.com/engine/reference/run/#/cmd-default-command-or-options) and defining `-E boostrap.memory_lock=true` there.
+   Also ensure `bootstrap.memory_lock` is set to `true` as explained in the [Elasticsearch Docs](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/setup-configuration-memory.html#mlockall). This can be achieved as shown in 1. e.g. by setting the env var `-e "bootstrap.memory_lock=true"`.
 
-2. Define [discovery.zen.minimum_master_nodes](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html) based on your requirements
+3. Define [discovery.zen.minimum_master_nodes](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html) based on your requirements
 
-3. The image [exposes](https://docs.docker.com/engine/reference/builder/#/expose) ports 9200 and 9300. For clusters it is recommended to randomize the listening ports with `--publish-all`, unless you are pinning one container per host
+4. The image [exposes](https://docs.docker.com/engine/reference/builder/#/expose) ports 9200 and 9300. For clusters it is recommended to randomize the listening ports with `--publish-all`, unless you are pinning one container per host
 
-4. Use the env var `ES_JAVA_OPTS` to set heap size, e.g. to use 16GB use `-e ES_JAVA_OPTS="-Xms16g -Xmx=16g"` with `docker run`. It is also recommended to set a memory limit for the container.
+5. Use the env var `ES_JAVA_OPTS` to set heap size, e.g. to use 16GB use `-e ES_JAVA_OPTS="-Xms16g -Xmx=16g"` with `docker run`. It is also recommended to set a memory limit for the container.
 
-5. It is recommended to pin your deployments to a specific version of the Elasticsearch Docker image, especially if you are using an orchestration framework like Kubernetes, Amazon ECS or Docker Swarm.
+6. It is recommended to pin your deployments to a specific version of the Elasticsearch Docker image, especially if you are using an orchestration framework like Kubernetes, Amazon ECS or Docker Swarm.
 
-6. Always use a volume bound on `/usr/share/elasticsearch/data`, as shown in the examples, for the following reasons:
+7. Always use a volume bound on `/usr/share/elasticsearch/data`, as shown in the examples, for the following reasons:
 
   - The data of your elasticsearch node won't be lost if the container gets killed
   - Elasticsearch is IO sensitive and you should not be using the Docker Storage Driver
   - Allows the use of advanced [Docker volume plugins](https://docs.docker.com/engine/extend/plugins/#volume-plugins)
 
-7. Consider centralizing your logs by using a different [logging driver](https://docs.docker.com/engine/admin/logging/overview/). Also note that the default json-file logging driver is not ideally suited for production use.
+8. Consider centralizing your logs by using a different [logging driver](https://docs.docker.com/engine/admin/logging/overview/). Also note that the default json-file logging driver is not ideally suited for production use.
 
-
-#### Configuring [Elasticsearch settings](https://www.elastic.co/guide/en/elasticsearch/reference/2.1/setup-configuration.html#settings):
-
-This can be done in two ways.
-
-- create your own `custom_elasticsearch.yml` conf file and override the one shipped by the image using `-v custom_elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml`
-
-- pass the parameters as docker env vars via the cli. Examples:
-
-  `docker run -d --memory=4g -v esdatavolume:/usr/share/elasticsearch/data $ELASTIC_REG/elasticsearch`
 
 ## Supported Docker versions
 
-The images have been tested on Docker 1.12.
+The images have been tested on Docker 1.12.1.
 
 ## Contributing, issues and testing
 

--- a/build/elasticsearch/Dockerfile
+++ b/build/elasticsearch/Dockerfile
@@ -35,8 +35,9 @@ COPY log4j2.properties /usr/share/elasticsearch/config/
 COPY bin/es-docker /usr/share/elasticsearch/bin/es-docker
 
 USER root
-RUN chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/elasticsearch.yml /usr/share/elasticsearch/config/log4j2.properties /usr/share/elasticsearch/bin/es-docker
-RUN chmod 0750 /usr/share/elasticsearch/bin/es-docker
+RUN chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/elasticsearch.yml /usr/share/elasticsearch/config/log4j2.properties /usr/share/elasticsearch/bin/es-docker && \
+    chmod 0750 /usr/share/elasticsearch/bin/es-docker
+
 USER elasticsearch
 CMD ["/bin/bash", "bin/es-docker"]
 

--- a/build/elasticsearch/Dockerfile
+++ b/build/elasticsearch/Dockerfile
@@ -22,21 +22,21 @@ RUN set -ex && for esdirs in config data logs; do \
         chown -R elasticsearch:elasticsearch "$esdirs"; \
     done
 
-COPY elasticsearch.yml /usr/share/elasticsearch/config/
-RUN chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/elasticsearch.yml
+COPY elasticsearch.yml config/
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
 
 USER elasticsearch
 
 # Install xpack
 RUN elasticsearch-plugin install --batch x-pack
 
-COPY elasticsearch.yml /usr/share/elasticsearch/config/
-COPY log4j2.properties /usr/share/elasticsearch/config/
-COPY bin/es-docker /usr/share/elasticsearch/bin/es-docker
+COPY elasticsearch.yml config/
+COPY log4j2.properties config/
+COPY bin/es-docker bin/es-docker
 
 USER root
-RUN chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/elasticsearch.yml /usr/share/elasticsearch/config/log4j2.properties /usr/share/elasticsearch/bin/es-docker && \
-    chmod 0750 /usr/share/elasticsearch/bin/es-docker
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml config/log4j2.properties bin/es-docker && \
+    chmod 0750 bin/es-docker
 
 USER elasticsearch
 CMD ["/bin/bash", "bin/es-docker"]

--- a/build/elasticsearch/Dockerfile
+++ b/build/elasticsearch/Dockerfile
@@ -32,7 +32,12 @@ RUN elasticsearch-plugin install --batch x-pack
 
 COPY elasticsearch.yml /usr/share/elasticsearch/config/
 COPY log4j2.properties /usr/share/elasticsearch/config/
+COPY bin/es-docker /usr/share/elasticsearch/bin/es-docker
 
-CMD ["/bin/sh", "bin/elasticsearch"]
+USER root
+RUN chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/elasticsearch.yml /usr/share/elasticsearch/config/log4j2.properties /usr/share/elasticsearch/bin/es-docker
+RUN chmod 0750 /usr/share/elasticsearch/bin/es-docker
+USER elasticsearch
+CMD ["/bin/bash", "bin/es-docker"]
 
 EXPOSE 9200 9300

--- a/build/elasticsearch/bin/es-docker
+++ b/build/elasticsearch/bin/es-docker
@@ -2,7 +2,7 @@
 
 # Run Elasticsearch and allow setting default settings via env vars
 #
-# e.g. Setting the env var -Ecluster.name=testcluster
+# e.g. Setting the env var cluster.name=testcluster
 #
 # will cause Elasticsearch to be invoked with -Ecluster.name=testcluster
 #

--- a/build/elasticsearch/bin/es-docker
+++ b/build/elasticsearch/bin/es-docker
@@ -10,17 +10,16 @@
 
 es_opts=''
 
-while IFS='='  read -r envvar_key envvar_value
+while IFS='=' read -r envvar_key envvar_value
 do
-    case $envvar_key in
-    [a-z.]*)
-        # es settings exported via env vars need to be lowercase
-
-        if [[ ! -z $envvar_key ]]; then
+    # Elasticsearch env vars need to have at least two dot separated lowercase words, e.g. `cluster.name`
+    if [[ "$envvar_key" =~ ^[a-z]+\.[a-z]+ ]]
+    then
+        if [[ ! -z $envvar_value ]]; then
           es_opt="-E${envvar_key}=${envvar_value}"
           es_opts+=" ${es_opt}"
         fi
-    esac
+    fi
 done < <(env)
 
 exec bin/elasticsearch ${es_opts}

--- a/build/elasticsearch/bin/es-docker
+++ b/build/elasticsearch/bin/es-docker
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Run Elasticsearch and allow setting default settings via env vars
+#
+# e.g. Setting the env var -Ecluster.name=testcluster
+#
+# will cause Elasticsearch to be invoked with -Ecluster.name=testcluster
+#
+# see https://www.elastic.co/guide/en/elasticsearch/reference/5.0/settings.html#_setting_default_settings
+
+es_opts=''
+
+while IFS='='  read -r envvar_key envvar_value
+do
+    case $envvar_key in
+    [a-z.]*)
+        # es settings exported via env vars need to be lowercase
+
+        if [[ ! -z $envvar_key ]]; then
+          es_opt="-E${envvar_key}=${envvar_value}"
+          es_opts+=" ${es_opt}"
+        fi
+    esac
+done < <(env)
+
+exec bin/elasticsearch ${es_opts}

--- a/build/elasticsearch/log4j2.properties
+++ b/build/elasticsearch/log4j2.properties
@@ -5,23 +5,5 @@ appender.console.name = console
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
 
-appender.audit_rolling.type = RollingFile
-appender.audit_rolling.name = audit_rolling
-appender.audit_rolling.fileName = ${sys:es.logs}_access.log
-appender.audit_rolling.layout.type = PatternLayout
-appender.audit_rolling.layout.pattern = [%d{ISO8601}] %m%n
-appender.audit_rolling.filePattern = ${sys:es.logs}_access-%d{yyyy-MM-dd}.log
-appender.audit_rolling.policies.type = Policies
-appender.audit_rolling.policies.time.type = TimeBasedTriggeringPolicy
-appender.audit_rolling.policies.time.interval = 1
-appender.audit_rolling.policies.time.modulate = true
-
-logger.xpack_security_audit_logfile.name = org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail
-logger.xpack_security_audit_logfile.level = info
-logger.xpack_security_audit_logfile.appenderRef.audit_rolling.ref = audit_rolling
-logger.xpack_security_audit_logfile.additivity = false
-
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,15 @@ services:
   # Can't use service elasticsearch=<num> for now due to named volumes
   elasticsearch1:
   # Equivalent to:
-  # docker run --rm --cap-add=IPC_LOCK --ulimit memlock=-1:-1 --ulimit nofile=65536:65536 -t -P --memory="4g" -v esdata:/usr/share/elasticsearch/data elasticsearch:5.0.0-alpha5 bin/elasticsearch
+  # docker run --rm --cap-add=IPC_LOCK --ulimit memlock=-1:-1 --ulimit nofile=65536:65536 -t -P --memory="4g" -e "discovery.zen.minimum_master_nodes=${ES_NODE_COUNT}" -v esdata:/usr/share/elasticsearch/data elasticsearch:5.0.0:beta1 bin/elasticsearch
     build:
       context: build/elasticsearch
       args:
         ELASTICSEARCH_VERSION: "${ELASTICSEARCH_VERSION}"
     cap_add:
       - IPC_LOCK
-    command: bin/elasticsearch -E discovery.zen.minimum_master_nodes=${ES_NODE_COUNT}
+    environment:
+      - discovery.zen.minimum_master_nodes=${ES_NODE_COUNT}
     image: "elasticsearch:${ELASTICSEARCH_VERSION}"
     mem_limit: 4g
     ports:
@@ -33,7 +34,9 @@ services:
         ELASTICSEARCH_VERSION: "${ELASTICSEARCH_VERSION}"
     cap_add:
       - IPC_LOCK
-    command: bin/elasticsearch -E discovery.zen.ping.unicast.hosts=elasticsearch1 -E discovery.zen.minimum_master_nodes=${ES_NODE_COUNT}
+    environment:
+      - discovery.zen.ping.unicast.hosts=elasticsearch1
+      - discovery.zen.minimum_master_nodes=${ES_NODE_COUNT}
     image: "elasticsearch:${ELASTICSEARCH_VERSION}"
     links:
       - elasticsearch1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # Can't use service elasticsearch=<num> for now due to named volumes
   elasticsearch1:
   # Equivalent to:
-  # docker run --rm --cap-add=IPC_LOCK --ulimit memlock=-1:-1 --ulimit nofile=65536:65536 -t -P --memory="4g" -e "discovery.zen.minimum_master_nodes=${ES_NODE_COUNT}" -v esdata:/usr/share/elasticsearch/data elasticsearch:5.0.0:beta1 bin/elasticsearch
+  # docker run --rm --cap-add=IPC_LOCK --ulimit memlock=-1:-1 --ulimit nofile=65536:65536 -t -P --memory="4g" -e "discovery.zen.minimum_master_nodes=${ES_NODE_COUNT}" -v esdata:/usr/share/elasticsearch/data elasticsearch:5.0.0:beta1
     build:
       context: build/elasticsearch
       args:


### PR DESCRIPTION
Elasticsearch parameters normally defined in elasticsearch.yml can be also defined as cli params with -E. This can be already be used by overriding CMD as `bin/elasticsearch -E<param1=value1> ...`

This PR adds the capability to also define ES params as Docker env vars. We are already doing this in Kibana and is a well established pattern in Docker to allow users define ES conf params as env vars if they wish.

