### PR TITLE
use docker healthcheck

### DIFF
--- a/build/elasticsearch/Dockerfile
+++ b/build/elasticsearch/Dockerfile
@@ -34,6 +34,14 @@ COPY elasticsearch.yml config/
 COPY log4j2.properties config/
 COPY bin/es-docker bin/es-docker
 
+# Healthcheck. Copied from
+# https://github.com/docker-library/healthcheck/blob/master/elasticsearch/Dockerfile
+# Set to yellow for the case of running 1 node, like note in 
+# tests/test_basic_index_crud.py # test_cluster_health_after_crud
+# TODO How to detect that 2 nodes are running and wait for "green"?
+COPY docker-healthcheck /usr/local/bin/
+HEALTHCHECK CMD ["docker-healthcheck","yellow"]
+
 USER root
 RUN chown elasticsearch:elasticsearch config/elasticsearch.yml config/log4j2.properties bin/es-docker && \
     chmod 0750 bin/es-docker

--- a/build/elasticsearch/docker-healthcheck
+++ b/build/elasticsearch/docker-healthcheck
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copied from https://github.com/docker-library/healthcheck/tree/master/elasticsearch/docker-healthcheck
+# Usage: docker-healthcheck  # by default, waits for "green"
+#        docker-healthcheck yellow # to wait for "yellow" instead
+
+target='green'
+if [ ! -z "$1" ]; then
+  target="$1"
+fi
+
+set -eo pipefail
+
+host="$(hostname --ip-address || echo '127.0.0.1')"
+
+if health="$(curl -fsSL "http://$host:9200/_cat/health?h=status")"; then
+  health="$(echo "$health" | sed -r 's/^[[:space:]]+|[[:space:]]+$//g')" # trim whitespace (otherwise we'll have "green ")
+  if [ "$health" = "$target" ]; then
+    exit 0
+  fi
+  echo >&2 "unexpected health status: $health"
+fi
+
+exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '2'
+version: '2.1'
 services:
   # Can't use service elasticsearch=<num> for now due to named volumes
   elasticsearch1:
@@ -66,6 +66,13 @@ services:
       - elasticsearch1:elasticsearch
     volumes:
       - $PWD/tests:/home/testuser/tests:ro
+    # Despite the python tester having a built-in healthcheck at tests/es_acceptance.py#wait_for_cluster_health
+    # Using the dockerfile healthcheck extends this to other services without having to re-code a wait for health status in each
+    # Note that this requires docker-compose.yml version 2.1, docker-compose>=1.11, docker>=1.13
+    depends_on:
+      elasticsearch1:
+        condition: service_healthy
+
 volumes:
   esdata1:
     driver: local


### PR DESCRIPTION
This PR adds support for [healthcheck](https://docs.docker.com/compose/compose-file/#/healthcheck) in the `docker-compose` file.
ATM, your repo's tester has a built-in `wait for health check` in `tests/es_acceptance.py` in function `wait_for_cluster_health`. Using docker's healthcheck, other services can benefit from this without having to re-code a `wait for health check` function in each. On the down-side, this requires upgrading the `yml` version from `2.0` to `2.1`, and hence upgrading `docker-compose` and `docker` to versions supporting it
* `docker info` output:  (1.13.1)   http://paste.ubuntu.com/24039459/
* `docker-compose` version: `docker-compose version 1.11.1, build 7c5d5e4`

Maybe creating a separate branch for this would be convenient?

Note that I ran `make` for testing and it failed with a `connection failed` error, but then again I ran `make` on master, and it also failed.