### PR TITLE
Fix envvar-arg mapping when spaces are in value.

### DIFF
--- a/build/elasticsearch/bin/es-docker
+++ b/build/elasticsearch/bin/es-docker
@@ -8,7 +8,7 @@
 #
 # see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#_setting_default_settings
 
-es_opts=''
+declare -a es_opts
 
 while IFS='=' read -r envvar_key envvar_value
 do
@@ -17,7 +17,7 @@ do
     then
         if [[ ! -z $envvar_value ]]; then
           es_opt="-E${envvar_key}=${envvar_value}"
-          es_opts+=" ${es_opt}"
+          es_opts+=("${es_opt}")
         fi
     fi
 done < <(env)
@@ -36,4 +36,4 @@ done < <(env)
 # will run in.
 export ES_JAVA_OPTS="-Des.cgroups.hierarchy.override=/ $ES_JAVA_OPTS"
 
-exec bin/elasticsearch ${es_opts}
+exec bin/elasticsearch "${es_opts[@]}"


### PR DESCRIPTION
The environment variable to ES option mapping in `es-docker` does not
work correctly when an option value contains whitespace.  This commit
changes the assembly of options to use an array instead of a string, and
then uses a proper all-array-items-to-words expansion at the end so
things like quoting don't need to be worried about.