### PR TITLE
Support an alternative, shell friendly, way to define ES settings

### DIFF
--- a/build/elasticsearch/bin/es-docker
+++ b/build/elasticsearch/bin/es-docker
@@ -1,23 +1,54 @@
 #!/bin/bash
 
-# Run Elasticsearch and allow setting default settings via env vars
+# Allow two different ways of defining Elasticsearch (-E type) settings using Docker env vars.
+# 1. As defined in the configuration files[1].
+#    Setting the docker env var cluster.name=testcluster will invoke Elasticsearch with:
+#    bin/elasticsearch -Ecluster.name=testcluster
 #
-# e.g. Setting the env var cluster.name=testcluster
+# 2. Using the ess__ prefix and replacing dots with __.
+#    This helps with shells and Kubernetes[2] that don't accept dots in env var names.
+#    Note the use of __ as a delimiter as Elasticsearch has settings already using _.
 #
-# will cause Elasticsearch to be invoked with -Ecluster.name=testcluster
+# Additionally pass through a couple of Elasticsearch parameters that don't have any dots.
 #
-# see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#_setting_default_settings
+# [1]: https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html#_setting_default_settings
+# [2]: https://github.com/kubernetes/kubernetes/issues/2707#issuecomment-285309156
 
 es_opts=''
+
+es_monadic_params=(
+    pidfile
+    processors
+)
+
+# Based on http://stackoverflow.com/a/14367368 !
+# Function to check if parameter $1 exists in the array passed as parameter $2
+item_in_array () {
+    local item
+    for item in "${@:2}"; do
+        if [[ "$item" == "$1" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
 
 while IFS='=' read -r envvar_key envvar_value
 do
     # Elasticsearch env vars need to have at least two dot separated lowercase words, e.g. `cluster.name`
-    if [[ "$envvar_key" =~ ^[a-z]+\.[a-z]+ ]]
+    # A few params though, such as pidfile, don't contain a dot. Pass those as well.
+    if [[ "$envvar_key" =~ ^[a-z]+\.[a-z]+ ]] || item_in_array "$envvar_key" "${es_monadic_params[@]}"
     then
         if [[ ! -z $envvar_value ]]; then
           es_opt="-E${envvar_key}=${envvar_value}"
           es_opts+=" ${es_opt}"
+        fi
+    # Convert env vars using the ess__ scheme to -E parameters that can be understood by Elasticsearch
+    elif [[ "$envvar_key" =~ ^ess__[a-zA-Z0-9_]+ ]]; then
+        if [[ ! -z $envvar_value ]]; then
+            stripped_envvar_key="${envvar_key#ess__}" # First strip the ess__ prefix
+            es_opt="-E${stripped_envvar_key//__/.}=${envvar_value}" # Then replace all __ with . and generate -E parameter
+            es_opts+=" ${es_opt}"
         fi
     fi
 done < <(env)

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - node.name=docker-test-node-1
       # Define max heap to a non default value and let us test it's set correctly
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
-      # Also try a shell-friendly, all capitals variable.
-      - ES_CLUSTER_NAME=docker-test-cluster
+      # Also try a shell-friendly variable.
+      - ess__cluster__name=docker-test-cluster
 
     # Expose elasticsearch to the host system, so that the test suite can see it.
     ports:
@@ -21,4 +21,4 @@ services:
     environment:
       - node.name=docker-test-node-2
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
-      - ES_CLUSTER_NAME=docker-test-cluster
+      - ess__cluster__name=docker-test-cluster

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
       # Also try a shell-friendly variable.
       - ess__cluster__name=docker-test-cluster
+      # And don't parse non-whitelisted parameters without dots
+      - irrelevantsetting=foo
 
     # Expose elasticsearch to the host system, so that the test suite can see it.
     ports:
@@ -21,4 +23,5 @@ services:
     environment:
       - node.name=docker-test-node-2
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - irrelevantsetting=foo
       - ess__cluster__name=docker-test-cluster

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -16,7 +16,7 @@ default_index = 'testdata'
 
 
 @fixture()
-def elasticsearch(Process, Command):
+def elasticsearch(Process, Command, File):
     class Elasticsearch:
         def __init__(self):
             self.url = 'http://localhost:9200'
@@ -27,6 +27,9 @@ def elasticsearch(Process, Command):
 
             # Retain a handle to the Command fixture letting us execute commands within the container(s)
             self.command = Command
+
+            # Retain a handle to the File fixture letting us check files inside the container(s)
+            self.localfile = File
 
             # Start each test with a clean slate.
             assert self.load_index_template().status_code == codes.ok
@@ -125,5 +128,8 @@ def elasticsearch(Process, Command):
             # Reset elasticsearch to its original state
             self.reset()
             return uninstall_output
+
+        def es_cmdline(self):
+            return self.localfile("/proc/1/cmdline").content_string
 
     return Elasticsearch()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,6 +15,11 @@ def test_setting_heapsize_with_an_environment_variable(elasticsearch):
     assert bool(heap_max_in_bytes)
 
 
-def test_ES_CLUSTER_NAME_environment_variable(elasticsearch):
+def test__ess__cluster__name_with_an_environment_variable(elasticsearch):
     # The fixture for this test comes from tests/docker-compose.yml
     assert elasticsearch.get_root_page()['cluster_name'] == ('docker-test-cluster')
+
+
+def test_non_whitelisted_setting_without_dot_with_an_environment_variable(elasticsearch):
+    # The fixture for this test comes from tests/docker-compose.yml
+    assert 'irrelevantsetting' not in elasticsearch.es_cmdline()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,7 +15,6 @@ def test_setting_heapsize_with_an_environment_variable(elasticsearch):
     assert bool(heap_max_in_bytes)
 
 
-@pytest.mark.xfail(raises=AssertionError, reason='Not yet implemented')
 def test_ES_CLUSTER_NAME_environment_variable(elasticsearch):
     # The fixture for this test comes from tests/docker-compose.yml
     assert elasticsearch.get_root_page()['cluster_name'] == ('docker-test-cluster')


### PR DESCRIPTION
Closes #33 

As per the commit description:

Shells allow a specific character class for environment variables:
`[a-zA-Z_]+[a-zA-Z0-9_]*`.  While Docker and POSIX[1] can deal with dots in environment names, Kubernetes is currently also affected[2] by this and as Elasticsearch settings contain dots, this creates
frustration for users who prefer customizing Elasticsearch using environment vars.

This commit offers the possibility for users to define settings using a schema prefixed with `ess__` and `__` instead of dots, like `ess__cluster__name=my-es-on-docker`.

As Elasticsearch also uses _ in some env vars (like `bootstrap.memory_lock`) and other env vars like `ES_JAVA_OPTS` are already prefixed with `ES_` we have to resort to the prefix `ess__` and using `__` as a delimiter.

Finally, also accept a few ES settings that don't contain dots in their name.

[1] http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html
[2] https://github.com/kubernetes/kubernetes/issues/2707#issuecomment-285309156