### PR TITLE
Ingest plugins and heap size fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ jinja2-cli[yaml]==0.6.0
 jinja2==2.9.5
 requests==2.13.0
 retrying==1.3.3
-testinfra==1.5.4
+testinfra==1.6.0

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -1,4 +1,5 @@
 # This Dockerfile was generated from templates/Dockerfile.j2
+{% set plugin_list = 'x-pack ingest-user-agent ingest-geoip' %}
 {% set tarball = 'elasticsearch-%s.tar.gz' % elastic_version -%}
 {% if '-' in version_tag -%}
 {%   set is_staging_build = True -%}
@@ -38,11 +39,11 @@ RUN set -ex && for esdirs in config data logs; do \
 
 USER elasticsearch
 
-# Install xpack
+# Install x-pack and also the ingest-{agent,geoip} modules required for Filebeat
 {% if is_staging_build -%}
-RUN eval ES_JAVA_OPTS="-Des.plugins.staging={{ staging_build_num }}" elasticsearch-plugin install --batch x-pack
+RUN for PLUGIN_TO_INST in {{ plugin_list }}; do eval ES_JAVA_OPTS="-Des.plugins.staging={{ staging_build_num }}" elasticsearch-plugin install --batch "$PLUGIN_TO_INST"; done
 {% else -%}
-RUN eval elasticsearch-plugin install --batch x-pack
+RUN for PLUGIN_TO_INST in {{ plugin_list }}; do elasticsearch-plugin install --batch "$PLUGIN_TO_INST"; done
 {% endif-%}
 
 COPY elasticsearch.yml config/

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - cluster.name=docker-test-cluster
       - node.name=docker-test-node-1
       # Test setting max heap to a non default value with environment variables.
-      - "ES_JAVA_OPTS=-Xms1151M -Xmx1151M"
+      - "ES_JAVA_OPTS=-Xms1152M -Xmx1152M"
       # Env vars not followed by a dot, should not be parsed by the wrapper script.
       - irrelevantsetting=foo
       # Capitalized or all-caps env vars should not be parsed either
@@ -23,6 +23,6 @@ services:
     environment:
       - cluster.name=docker-test-cluster
       - node.name=docker-test-node-2
-      - "ES_JAVA_OPTS=-Xms1151M -Xmx1151M"
+      - "ES_JAVA_OPTS=-Xms1152M -Xmx1152M"
       - irrelevantsetting=foo
       - NonESRelatedVariable=bar

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -66,6 +66,11 @@ def elasticsearch(host):
             """Return an array of node OS statistics"""
             return self.get('/_nodes/stats/os').json()['nodes'].values()
 
+        def get_node_plugins(self):
+            """Return an array of node plugins"""
+            nodes = self.get('/_nodes/plugins').json()['nodes'].values()
+            return [node['plugins'] for node in nodes]
+
         def get_node_jvm_stats(self):
             """Return an array of node JVM statistics"""
             nodes = self.get('/_nodes/stats/jvm').json()['nodes'].values()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -15,20 +15,15 @@ default_index = 'testdata'
 
 
 @fixture()
-def elasticsearch(Process, Command, File):
-    class Elasticsearch:
+def elasticsearch(host):
+    class Elasticsearch():
         def __init__(self):
             self.url = 'http://localhost:9200'
             self.auth = HTTPBasicAuth('elastic', 'changeme')
 
             self.assert_healthy()
-            self.process = Process.get(comm='java')
 
-            # Retain a handle to the Command fixture letting us execute commands within the container(s)
-            self.command = Command
-
-            # Retain a handle to the File fixture letting us check files inside the container(s)
-            self.localfile = File
+            self.process = host.process.get(comm='java')
 
             # Start each test with a clean slate.
             assert self.load_index_template().status_code == codes.ok
@@ -118,15 +113,15 @@ def elasticsearch(Process, Command, File):
         def uninstall_plugin(self, plugin_name):
             # This will run on only one host, but this is ok for the moment
             # TODO: as per http://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
-            uninstall_output = self.command.run(' '.join(["bin/elasticsearch-plugin",
-                                                          "-s",
-                                                          "remove",
-                                                          "{}".format(plugin_name)]))
+            uninstall_output = host.run(' '.join(["bin/elasticsearch-plugin",
+                                                  "-s",
+                                                  "remove",
+                                                  "{}".format(plugin_name)]))
             # Reset elasticsearch to its original state
             self.reset()
             return uninstall_output
 
         def es_cmdline(self):
-            return self.localfile("/proc/1/cmdline").content_string
+            return host.file("/proc/1/cmdline").content_string
 
     return Elasticsearch()

--- a/tests/test_base_os.py
+++ b/tests/test_base_os.py
@@ -1,3 +1,3 @@
-def test_base_os(SystemInfo):
-    assert SystemInfo.distribution == 'centos'
-    assert SystemInfo.release == '7'
+def test_base_os(host):
+    assert host.system_info.distribution == 'centos'
+    assert host.system_info.release == '7'

--- a/tests/test_es_plugins.py
+++ b/tests/test_es_plugins.py
@@ -5,3 +5,17 @@ from requests import codes
 def test_uninstall_xpack_plugin(elasticsearch):
     # Ensure plugins can be uninstalled, see https://github.com/elastic/elasticsearch/issues/24231
     assert elasticsearch.uninstall_plugin("x-pack").exit_status == 0
+
+
+def test_IngestUserAgentPlugin_is_installed(elasticsearch):
+    # Ensure IngestUserAgentPlugin is present on all nodes
+    for nodeplugins in elasticsearch.get_node_plugins():
+        plugin_classnames = [plugin['classname'] for plugin in nodeplugins]
+        assert 'org.elasticsearch.ingest.useragent.IngestUserAgentPlugin' in plugin_classnames
+
+
+def test_IngestGeoIpPlugin_is_installed(elasticsearch):
+    # Ensure IngestGeoIpPlugin is present on all nodes
+    for nodeplugins in elasticsearch.get_node_plugins():
+        plugin_classnames = [plugin['classname'] for plugin in nodeplugins]
+        assert 'org.elasticsearch.ingest.geoip.IngestGeoIpPlugin' in plugin_classnames

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,11 +15,16 @@ def test_setting_cluster_name_with_an_environment_variable(elasticsearch):
 def test_setting_heapsize_with_an_environment_variable(elasticsearch):
     # The fixture for this test comes from tests/docker-compose.yml.
     #
-    # The number of bytes that we assert is not exactly what we specify
-    # in the fixture. The exact value would be 1206910976, but due to JVM
-    # subtleties, the actual number is lower.
+    # The number of bytes that we assert is not exactly what we
+    # specify in the fixture. This is due to jvm honoring the
+    # generation and survivor ratios, rounding and alignments.  It is
+    # enough if Elasticsearch reports a max heap size within 64MB of
+    # the target value set in the fixture (=1152MB).
+
+    mem_delta_mb = 64
     for jvm in elasticsearch.get_node_jvm_stats():
-        assert jvm['mem']['heap_max_in_bytes'] == 1173094400
+        reported_heap_max_in_mb = int(jvm['mem']['heap_max_in_bytes'] / (1024**2))
+        assert abs(reported_heap_max_in_mb - 1152) < mem_delta_mb
 
 
 def test_envar_not_including_a_dot_is_not_presented_to_elasticsearch(elasticsearch):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,14 +1,14 @@
 from .fixtures import elasticsearch
 
 
-def test_group_properties(Group, elasticsearch):
-    group = Group('elasticsearch')
+def test_group_properties(host, elasticsearch):
+    group = host.group('elasticsearch')
     assert group.exists
     assert group.gid == 1000
 
 
-def test_user_properties(User, elasticsearch):
-    user = User('elasticsearch')
+def test_user_properties(host, elasticsearch):
+    user = host.user('elasticsearch')
     assert user.uid == 1000
     assert user.gid == 1000
     assert user.home == '/usr/share/elasticsearch'


### PR DESCRIPTION
As per the commit descriptions:

- Make test heap size setting via env var more lenient: https://github.com/elastic/elasticsearch-docker/commit/55bce3bf2265a567c37a4992f1dfe86296d78582
- Bundle ingest-geoip and ingest-user-agent plugins (issue #48): https://github.com/elastic/elasticsearch-docker/commit/dca299228a162731ebcfd3fe3051582a1b911ee4 and add tests for them: https://github.com/elastic/elasticsearch-docker/commit/4fdabbeea942b6a39ac79ec1ff0b6da4f420a58a
- Switch to testinfra 1.6.0: https://github.com/elastic/elasticsearch-docker/commit/1924437811f2f9af6a97b650d24c75b0a46256e1