### PR TITLE
Feature/kubernetes env variables

### DIFF
--- a/build/elasticsearch/bin/es-docker
+++ b/build/elasticsearch/bin/es-docker
@@ -12,6 +12,16 @@ declare -a es_opts
 
 while IFS='=' read -r envvar_key envvar_value
 do
+    # Kuberenetes does only support environment variables with capital letters and underscores
+    # following lines will normalize kubernetes variables with double __ to a elasticsearch compatible environment variable
+    if [[ "$envvar_key" =~ ^[A-Z]+(_{2}[A-Z]+)+ ]]
+    then
+        if [[ ! -z $envvar_value ]] ; then
+            envvar_key=${envvar_key//__/\.} # replace __ with .
+            envvar_key=${envvar_key,,} # lowercase
+        fi
+    fi
+
     # Elasticsearch env vars need to have at least two dot separated lowercase words, e.g. `cluster.name`
     if [[ "$envvar_key" =~ ^[a-z_]+\.[a-z_]+ ]]
     then

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       # Try setting a few options with environment variables.
       - cluster.name=docker-test-cluster
       - node.name=docker-test-node-1
+      - DISCOVERY__ZEN__MINIMUM_MASTER_NODES=2
       # Also try a parameter containing an underscore character.
       - thread_pool.bulk.queue_size=500
       # Test setting max heap to a non default value with environment variables.
@@ -30,6 +31,7 @@ services:
     environment:
       - cluster.name=docker-test-cluster
       - node.name=docker-test-node-2
+      - DISCOVERY__ZEN__MINIMUM_MASTER_NODES=2
       - thread_pool.bulk.queue_size=500
       - "ES_JAVA_OPTS=-Xms1152M -Xmx1152M"
       - irrelevantsetting=foo

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,6 +12,10 @@ def test_setting_cluster_name_with_an_environment_variable(elasticsearch):
     assert elasticsearch.get_root_page()['cluster_name'] == ('docker-test-cluster')
 
 
+def test_setting_discovery_zen_minimum_master_nodes_with_an_environment_variable(elasticsearch):
+    assert elasticsearch.get_root_page()['discovery_zen_minimum_master_nodes'] == (2)
+
+
 def test_setting_heapsize_with_an_environment_variable(elasticsearch):
     # The fixture for this test comes from tests/docker-compose.yml.
     #


### PR DESCRIPTION
The PR does contain a test_case, but I'm unable to do the `make build` step.

```bash
make
rm -f docker-compose.yml build/elasticsearch/Dockerfile
jinja2 \
  -D elastic_version='5.5.0' \
  -D staging_build_num='' \
  -D release_manager='' \
  templates/Dockerfile.j2 > build/elasticsearch/Dockerfile
docker build -t docker.elastic.co/elasticsearch/elasticsearch:5.5.0 build/elasticsearch
Sending build context to Docker daemon  10.24kB
Step 1/20 : FROM centos:7
 ---> 36540f359ca3
Step 2/20 : LABEL maintainer "Elastic Docker Team <docker@elastic.co>"
 ---> Using cache
 ---> 14ea8a620651
Step 3/20 : ENV ELASTIC_CONTAINER true
 ---> Using cache
 ---> f1fb1eaa8010
Step 4/20 : ENV PATH /usr/share/elasticsearch/bin:$PATH
 ---> Using cache
 ---> 892fd5bf16c6
Step 5/20 : ENV JAVA_HOME /usr/lib/jvm/jre-1.8.0-openjdk
 ---> Using cache
 ---> 9a0a59f4f7a2
Step 6/20 : RUN yum update -y && yum install -y java-1.8.0-openjdk-headless wget which && yum clean all
 ---> Running in be21494aff5f
Loaded plugins: fastestmirror, ovl


 One of the configured repositories failed (Unknown),
 and yum doesn't have enough cached data to continue. At this point the only
 safe thing yum can do is fail. There are a few ways to work "fix" this:

     1. Contact the upstream for the repository and get them to fix the problem.

     2. Reconfigure the baseurl/etc. for the repository, to point to a working
        upstream. This is most often useful if you are using a newer
        distribution release than is supported by the repository (and the
        packages for the previous distribution release still work).

     3. Run the command with the repository temporarily disabled
            yum --disablerepo=<repoid> ...

     4. Disable the repository permanently, so yum won't use it by default. Yum
        will then just ignore the repository until you permanently enable it
        again or use --enablerepo for temporary usage:

            yum-config-manager --disable <repoid>
        or
            subscription-manager repos --disable=<repoid>

     5. Configure the failing repository to be skipped, if it is unavailable.
        Note that yum will try to contact the repo. when it runs most commands,
        so will have to try and fail each time (and thus. yum will be be much
        slower). If it is a very temporary problem though, this is often a nice
        compromise:

            yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true

Cannot find a valid baseurl for repo: base/7/x86_64
Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
12: Timeout on http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container: (28, 'Resolving timed out after 30946 milliseconds')
The command '/bin/sh -c yum update -y && yum install -y java-1.8.0-openjdk-headless wget which && yum clean all' returned a non-zero code: 1
Makefile:50: recipe for target 'build' failed
make: *** [build] Error 1
```