### PR TITLE
Adding support to different linux platform  by passing extra paramete…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,8 @@ dockerfile: venv templates/Dockerfile.j2
 	  -D elastic_version='$(ELASTIC_VERSION)' \
 	  -D staging_build_num='$(STAGING_BUILD_NUM)' \
 	  -D release_manager='$(RELEASE_MANAGER)' \
-	  templates/Dockerfile.j2 > build/elasticsearch/Dockerfile
+	  -D from_image_name='$(FROM_IMAGE_NAME)' \	  
+	  	  templates/Dockerfile.j2 > build/elasticsearch/Dockerfile
 
 # Generate the docker-compose.yml from a Jinja2 template.
 docker-compose.yml: venv templates/docker-compose.yml.j2

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -18,7 +18,11 @@
 {%   set url_root = 'https://artifacts.elastic.co/downloads/elasticsearch' -%}
 {% endif -%}
 
+{% if from_image_name -%}
+FROM {{ from_image_name }}
+{% else -%}
 FROM centos:7
+{% endif -%}
 LABEL maintainer "Elastic Docker Team <docker@elastic.co>"
 
 ENV ELASTIC_CONTAINER true


### PR DESCRIPTION
…r as from_image_name , So that this changes  will support to  create elasticsearch docker image for other linux base os images well, By default if there is no parameter passed then it will create for centos. 

Initial changes were supporting only for base centos image.  New changes can support for different linux base os images.  If support we pass the command like 'make build from_image_name="registry.access.redhat.com/rhel7.3" then it will create the elasticsearch docker image for "registry.access.redhat.com/rhel7.3" this base image.  this way we can pass any other base linux os image name on which we can create docker image.   New code still supporting for centos as default os if no parameter is passed like "make build". 

Does this PR include tests?  No

`elasticsearch-docker` is developed under a test-driven workflow, so please refrain from submitting patches without test coverage. If you are not familiar with testing in Python, please raise an issue instead.
