### PR TITLE
Template es-docker wrapper startup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 build/elasticsearch/Dockerfile
 build/elasticsearch/Dockerfile-*
 build/elasticsearch/elasticsearch*.tar.gz
+build/elasticsearch/bin/es-docker-*
 tests/docker-compose*.yml

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ else
 	-f docker-compose.hostports.yml
 endif
 
-.PHONY: all dockerfile docker-compose test test-build lint clean pristine run run-single run-cluster build release-manager release-manager-snapshot push
+.PHONY: all dockerfile docker-compose es-docker test test-build lint clean pristine run run-single run-cluster build release-manager release-manager-snapshot push
 
 # Default target, build *and* run tests
 all: build test
@@ -147,7 +147,7 @@ venv: requirements.txt
 	touch venv;\
 
 # Generate the Dockerfiles for each image flavor from a Jinja2 template.
-dockerfile: venv templates/Dockerfile.j2
+dockerfile: venv templates/Dockerfile.j2 es-docker
 	$(foreach FLAVOR, $(IMAGE_FLAVORS), \
 	 jinja2 \
 	   -D elastic_version='$(ELASTIC_VERSION)' \
@@ -167,4 +167,11 @@ docker-compose: venv templates/docker-compose.yml.j2 templates/docker-compose-fr
 	 jinja2 \
 	  -D image_flavor='$(FLAVOR)' \
 	  templates/docker-compose-fragment.yml.j2 > tests/docker-compose-$(FLAVOR).yml; \
+	)
+
+es-docker: templates/es-docker.j2
+	$(foreach FLAVOR, $(IMAGE_FLAVORS), \
+	 jinja2 \
+	  -D image_flavor='$(FLAVOR)' \
+	  templates/es-docker.j2 > build/elasticsearch/bin/es-docker-$(FLAVOR); \
 	)

--- a/templates/Dockerfile.j2
+++ b/templates/Dockerfile.j2
@@ -73,7 +73,7 @@ USER root
 
 {% if image_flavor == 'oss' -%}
 COPY elasticsearch.yml log4j2.properties config/
-COPY bin/es-docker bin/es-docker
+COPY bin/es-docker-{{ image_flavor }} bin/es-docker
 
 RUN chown elasticsearch:elasticsearch \
       config/elasticsearch.yml \
@@ -83,7 +83,7 @@ RUN chown elasticsearch:elasticsearch \
 {% elif image_flavor == 'basic' -%}
 COPY elasticsearch.yml log4j2.properties config/
 COPY x-pack/log4j2.properties config/x-pack/
-COPY bin/es-docker bin/es-docker
+COPY bin/es-docker-{{ image_flavor }} bin/es-docker
 
 # Note: basic will be available after 6.0.0-beta1
 RUN echo 'xpack.license.self_generated.type: basic' >>config/elasticsearch.yml
@@ -97,7 +97,7 @@ RUN chown elasticsearch:elasticsearch \
 {% elif image_flavor == 'platinum' -%}
 COPY elasticsearch.yml certgen_instances.yml log4j2.properties config/
 COPY x-pack/log4j2.properties config/x-pack/
-COPY bin/es-docker bin/es-docker
+COPY bin/es-docker-{{ image_flavor }} bin/es-docker
 
 RUN echo 'xpack.license.self_generated.type: trial' >>config/elasticsearch.yml
 

--- a/templates/es-docker.j2
+++ b/templates/es-docker.j2
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# This script was generated from the template at templates/es-docker.j2
+#
 # Run Elasticsearch and allow setting default settings via env vars
 #
 # e.g. Setting the env var cluster.name=testcluster
@@ -35,6 +37,7 @@ done < <(env)
 # will run in.
 export ES_JAVA_OPTS="-Des.cgroups.hierarchy.override=/ $ES_JAVA_OPTS"
 
+{% if image_flavor == 'platinum' -%}
 # Determine if x-pack is enabled
 if bin/elasticsearch-plugin list -s | grep x-pack; then
     # Setting ELASTIC_PASSWORD is mandatory on the *first* node (unless
@@ -58,5 +61,6 @@ if bin/elasticsearch-plugin list -s | grep x-pack; then
                  )
     fi
 fi
+{% endif -%}
 
 exec bin/elasticsearch "${es_opts[@]}"


### PR DESCRIPTION
The CMD shell script that starts Elasticsearch needs some parametrization that is only know during build time.

Create customized versions of the es-docker wrapper script depending on image flavor and integrate in the build process.