### PR TITLE
Added support for alphanumeric configuration parameters

### DIFF
--- a/build/elasticsearch/bin/docker-entrypoint.sh
+++ b/build/elasticsearch/bin/docker-entrypoint.sh
@@ -51,7 +51,7 @@ declare -a es_opts
 while IFS='=' read -r envvar_key envvar_value
 do
     # Elasticsearch env vars need to have at least two dot separated lowercase words, e.g. `cluster.name`
-    if [[ "$envvar_key" =~ ^[a-z_]+\.[a-z_]+ ]]; then
+    if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ ]]; then
         if [[ ! -z $envvar_value ]]; then
           es_opt="-E${envvar_key}=${envvar_value}"
           es_opts+=("${es_opt}")


### PR DESCRIPTION
Support for numeric characters are required 
https://www.elastic.co/guide/en/elasticsearch/plugins/6.1/repository-s3-client.html

Does this PR include tests? Unfortunately, no. 
Adding any S3 config parameters requires the S3 plugin installed, and unfortunately, adding:
`bin/elasticsearch-plugin install repository-s3` as a first command in the compose file doesn't work with the 
**test_es_can_run_with_random_uid_and_write_to_bind_mounted_datadir** test

