### PR TITLE
Update docker-entrypoint.sh to allow a user mounted script to be sourced to allow for extra settings

### DIFF
--- a/build/elasticsearch/bin/docker-entrypoint.sh
+++ b/build/elasticsearch/bin/docker-entrypoint.sh
@@ -88,6 +88,11 @@ if [[ -d bin/x-pack ]]; then
     fi
 fi
 
+if [ -f /custom/user_init.sh ]
+then
+. /custom/user_init.sh
+fi
+
 if [[ "$(id -u)" == "0" ]]; then
     # If requested and running as root, mutate the ownership of bind-mounts
     if [[ -n "$TAKE_FILE_OWNERSHIP" ]]; then


### PR DESCRIPTION
This PR is part of a bash script so I'm not sure how you want me to test it.

It will simply allow a custom script to be mounted into the image so that a user can specify commands to be run on start up.

See Issue #189 on why I think this is a good idea.

Thanks for any consideration