### PR TITLE
Fix handling of processors setting

### DIFF
--- a/build/elasticsearch/bin/docker-entrypoint.sh
+++ b/build/elasticsearch/bin/docker-entrypoint.sh
@@ -50,8 +50,10 @@ declare -a es_opts
 
 while IFS='=' read -r envvar_key envvar_value
 do
-    # Elasticsearch env vars need to have at least two dot separated lowercase words, e.g. `cluster.name`
-    if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ ]]; then
+    # Elasticsearch settings need to have at least two dot separated lowercase
+    # words, e.g. `cluster.name`, except for `processors` which we handle
+    # specially
+    if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ || "$envvar_key" == "processors" ]]; then
         if [[ ! -z $envvar_value ]]; then
           es_opt="-E${envvar_key}=${envvar_value}"
           es_opts+=("${es_opt}")

--- a/templates/docker-compose-fragment.yml.j2
+++ b/templates/docker-compose-fragment.yml.j2
@@ -22,6 +22,8 @@ services:
       - node.name=docker-test-node-1
       # Also try a parameter containing an underscore character.
       - thread_pool.search.queue_size=500
+      # And try the special processors setting.
+      - processors=1
       # Test setting max heap to a non default value with environment variables.
       - "ES_JAVA_OPTS=-Xms1152M -Xmx1152M"
       # Env vars not followed by a dot, should not be parsed by the wrapper script.
@@ -48,6 +50,7 @@ services:
       - cluster.name=docker-test-cluster
       - node.name=docker-test-node-2
       - thread_pool.search.queue_size=500
+      - processors=1
       - "ES_JAVA_OPTS=-Xms1152M -Xmx1152M"
       - irrelevantsetting=foo
       - NonESRelatedVariable=bar

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -103,6 +103,10 @@ def elasticsearch(host):
             nodes = self.get('/_nodes?filter_path=**.thread_pool').json()['nodes'].values()
             return [node['settings']['thread_pool']['search']['queue_size'] for node in nodes]
 
+        def get_processors_settings(self):
+            nodes = self.get('/_nodes/settings?filter_path=**.processors').json()['nodes'].values()
+            return [node['settings']['processors'] for node in nodes]
+
         def get_node_jvm_stats(self):
             """Return an array of node JVM statistics"""
             nodes = self.get('/_nodes/stats/jvm').json()['nodes'].values()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -103,7 +103,7 @@ def elasticsearch(host):
             nodes = self.get('/_nodes?filter_path=**.thread_pool').json()['nodes'].values()
             return [node['settings']['thread_pool']['search']['queue_size'] for node in nodes]
 
-        def get_processors_settings(self):
+        def get_processors_setting(self):
             nodes = self.get('/_nodes/settings?filter_path=**.processors').json()['nodes'].values()
             return [node['settings']['processors'] for node in nodes]
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -33,6 +33,12 @@ def test_parameter_containing_underscore_with_an_environment_variable(elasticsea
         assert '500' == thread_pool_queue_size
 
 
+def test_setting_processors(elasticsearch):
+    # The fixture for this test comes from tests/docker-compose.yml
+    for processors in elasticsearch.get_processors_setting():
+        assert '1' == processors
+
+
 def test_envar_not_including_a_dot_is_not_presented_to_elasticsearch(elasticsearch):
     # The fixture for this test comes from tests/docker-compose.yml
     assert 'irrelevantsetting' not in elasticsearch.es_cmdline()


### PR DESCRIPTION
Elasticsearch has a special setting called "processors" that is used to configure the size of the internal threadpools, by telling Elasticsearch to prentend that it is running on a system with the specified number of processors rather than the detected number of processors. This should be used in conjunction with actually limiting Elasticsearch to the specified number of processors, via CPU pinning. However, this setting does not currently work with the Docker image when configured via an environment variable passed into the container. This is because the logic for converting an environment variable into a setting assumes that the setting must have at least two words separated by a dot. This is close to correct, but not correct for the processors settings. This commit adds special handling for the processors setting so that it can be set via an environment variable.

Relates elastic/elasticsearch#33633