### PR TITLE
Fix node name logging

### DIFF
--- a/build/elasticsearch/log4j2.properties
+++ b/build/elasticsearch/log4j2.properties
@@ -3,7 +3,7 @@ status = error
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker%m%n
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console

--- a/build/elasticsearch/log4j2.properties
+++ b/build/elasticsearch/log4j2.properties
@@ -3,7 +3,7 @@ status = error
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker%m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console


### PR DESCRIPTION
In upstream Elasticsearch we have modified how the node name is logged. This commit makes the logging configuration in the Docker image consistent with this change.