### PR TITLE
Do not hard code pytest path

### DIFF
--- a/bin/pytest
+++ b/bin/pytest
@@ -2,4 +2,4 @@
 #
 # A wrapper for `pytest` to handle the appropriate Testinfra arguments.
 
-./venv/bin/pytest --verbose --connection=docker --hosts=elasticsearch1 $@
+pytest --verbose --connection=docker --hosts=elasticsearch1 $@


### PR DESCRIPTION
Why is this hardcoded?

Does this PR include tests?
No

`elasticsearch-docker` is developed under a test-driven workflow, so please refrain from submitting patches without test coverage. If you are not familiar with testing in Python, please raise an issue instead.
