### PR TITLE
Get es_opts faster in docker-entrypoint.sh

### DIFF
--- a/.tedi/template/bin/docker-entrypoint.sh
+++ b/.tedi/template/bin/docker-entrypoint.sh
@@ -48,18 +48,14 @@ fi
 
 declare -a es_opts
 
-while IFS='=' read -r envvar_key envvar_value
+while read -r es_opt
 do
     # Elasticsearch settings need to have at least two dot separated lowercase
     # words, e.g. `cluster.name`, except for `processors` which we handle
     # specially
-    if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ || "$envvar_key" == "processors" ]]; then
-        if [[ ! -z $envvar_value ]]; then
-          es_opt="-E${envvar_key}=${envvar_value}"
-          es_opts+=("${es_opt}")
-        fi
-    fi
-done < <(env)
+    es_opts+=("-E${es_opt}")
+    
+done < <( env | grep -E '^([a-z0-9_]+(\.[a-z0-9_]+)+|processors)=.+' )
 
 # The virtual file /proc/self/cgroup should list the current cgroup
 # membership. For each hierarchy, you can follow the cgroup path from


### PR DESCRIPTION
Hi

I use ES on k8s 1.11, and there are many `Services` in the same namespace. 
When a container is started, environment variables related with `Services` are injected. 
(https://kubernetes.io/docs/concepts/services-networking/service/#discovering-services)

Problem is, if there are many env vars, iteration for `es_opts` takes several minutes. It seems that `read` is especially slow. So, in this PR it filters environment variables before iteration.
